### PR TITLE
change "emtpy" json from {} to [].

### DIFF
--- a/Settings/InstalledPackages.cs
+++ b/Settings/InstalledPackages.cs
@@ -39,7 +39,7 @@ namespace WinDurango.UI.Settings
             if (!File.Exists(filePath))
             {
                 Logger.WriteInformation("Creating empty InstalledPackages.json");
-                File.WriteAllText(filePath, "{}");
+                File.WriteAllText(filePath, "[]");
                 _installedPackages = [];
             }
             else


### PR DESCRIPTION
Fixes `System.Text.Json.JsonException: The JSON value could not be converted to System.Collections.Generic.List1[WinDurango.UI.Settings.installedPackage]. Path: $ | LineNumber: 0 | BytePositionInLine: 1.`
when trying to load empty installedPackages data