### PR TITLE
Qol patch

### DIFF
--- a/Controls/AppTile.xaml.cs
+++ b/Controls/AppTile.xaml.cs
@@ -233,7 +233,7 @@ namespace WinDurango.UI.Controls
 
             RightTapped += (sender, e) =>
             {
-                rcFlyout.ShowAt(sender as FrameworkElement);
+                rcFlyout.ShowAt(sender as FrameworkElement, e.GetPosition(sender as UIElement));
             };
 
             startButton.Tapped += async (s, e) =>

--- a/Utils/WinDurangoPatcher.cs
+++ b/Utils/WinDurangoPatcher.cs
@@ -81,17 +81,17 @@ namespace WinDurango.UI.Utils
 
                 try
                 {
-                    controller?.Update($"Downloading WinDurango {relName}", 20);
-
                     await using Stream httpStream = await httpClient.GetStreamAsync(dlLink);
                     await using FileStream stream = new(archivePath, FileMode.Create, FileAccess.Write, FileShare.None);
-                    controller?.Update("Writing release zip", 30);
-                    // why so slow?
-                    await httpStream.CopyToAsync(stream);
+                    
+                    //controller?.Update("Writing release zip", 30);
+                    // Commented ^, as above code does not start the download, the download is done in the httpStream.CopyToAsync function
+                    controller?.Update($"Downloading WinDurango {relName}", 30);
+                    await httpStream.CopyToAsync(stream, 1048576); // 1MB Buffer
                 }
                 catch (Exception ex)
                 {
-                    await controller.Fail(ex.Message, "Failed to download/write zip");
+                    await controller!.Fail(ex.Message, "Failed to download/write zip");
                     return false;
                 }
 

--- a/Utils/XHandler.cs
+++ b/Utils/XHandler.cs
@@ -57,7 +57,7 @@ namespace WinDurango.UI.Utils
         public static List<Package> GetXPackages(List<Package> packages)
         {
             // first try implementation and it worked hell yeah
-            List<Package> result = new();
+            List<Package> result = [];
             foreach (Package package in packages)
             {
                 string installPath = package.InstalledPath;
@@ -67,9 +67,9 @@ namespace WinDurango.UI.Utils
                     continue;
 
                 string manifest;
-                using (var stream = File.OpenRead(manifestPath))
+                using (FileStream stream = File.OpenRead(manifestPath))
                 {
-                    var reader = new StreamReader(stream);
+                    StreamReader reader = new(stream);
                     manifest = reader.ReadToEnd();
                 }
 
@@ -82,7 +82,7 @@ namespace WinDurango.UI.Utils
                 XElement osName = prerequisites?.Descendants().FirstOrDefault(e => e.Name.LocalName == "OSName");
                 XElement osPackageDependency = dependencies?.Descendants().FirstOrDefault(e => e.Name.LocalName == "OSPackageDependency");
 
-                if ((osName != null && osName.Value.ToLower() == "era") || (osPackageDependency != null && osPackageDependency.Attribute("Name")?.Value == "Microsoft.GameOs"))
+                if ((osName != null && osName.Value.Equals("era", System.StringComparison.InvariantCultureIgnoreCase)) || (osPackageDependency != null && osPackageDependency.Attribute("Name")?.Value == "Microsoft.GameOs"))
                 {
                     result.Add(package);
                 }


### PR DESCRIPTION
When right-clicking AppTile the Flyout now opens next to cursor instead to top of AppTile card
Also removed "Writing release zip" status in PatchPackage and moved "Downloading WinDurango {relName}" to it's place as the file download is done in CopyToAsync function and cleaned some parts of the code