### PR TITLE
Fix a null reference exception in UIConfig.cs

### DIFF
--- a/Settings/UiConfig.cs
+++ b/Settings/UiConfig.cs
@@ -112,10 +112,6 @@ public class UiConfig : IConfig
             JsonSerializerOptions options = new();
             options.WriteIndented = true;
             File.WriteAllText(_settingsFile, JsonSerializer.Serialize(Settings, options));
-            /* FIXME: For some reason unknown to me, App.MainWindow is null here, but only if the Settings were generated before e.g. on first launch
-             * No biggy in that case as nothing has been customized yet, but depending on the reason this might cause problems.
-            */
-            App.MainWindow.LoadSettings();
         }
         catch (Exception ex)
         {
@@ -135,6 +131,7 @@ public class UiConfig : IConfig
 
         property.SetValue(Settings, Convert.ChangeType(value, property.PropertyType));
         Save();
+        App.MainWindow.LoadSettings();
     }
 
 }


### PR DESCRIPTION
- UiConfig.Save no longer reloads the settings after saving. This change fixes a null reference exception if App.MainWindow is null (As pointed out by this comment: `FIXME: For some reason unknown to me, App.MainWindow is null here, but only if the Settings were generated before e.g. on first launch` above the line where the loading is done). Not using the window in UiConfig.Save fixes this issue.
- The settings are now only reloaded in UiConfig.Set